### PR TITLE
feat: retry pull script download and sensor image pull on transient failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ To use this action in your workflow, add the following step:
 | `resource_group` | Azure resource group name | No | - | `my-resource-group` |
 | `subscription` | Azure subscription id | No | - | `subscription-id` |
 | `falcon_image_platform` | Specify image architecture when using the image pulled by the action | No | `x86_64` | `x86_64`, `aarch64` |
+| `retry_max_attempts` | Number of attempts when downloading the pull script or pulling the sensor image, used to ride out transient network failures | No | `3` | `5` |
+| `retry_delay_seconds` | Seconds to wait between retry attempts | No | `5` | `10` |
 
 ## Examples
 

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,14 @@ inputs:
     description: 'Specify sensor platform to retrieve when pulling from CrowdStrike repository'
     required: false
     default: x86_64
+  retry_max_attempts:
+    description: 'Number of attempts when downloading the pull script or pulling the sensor image, used to ride out transient network failures'
+    required: false
+    default: '3'
+  retry_delay_seconds:
+    description: 'Seconds to wait between retry attempts'
+    required: false
+    default: '5'
   cloud_service:
     description: 'Cloud Service platform. Allowed values: ACA | ACI | ECS_FARGATE | CLOUDRUN'
     required: false
@@ -68,6 +76,8 @@ runs:
         INPUT_FALCON_REGION: ${{ inputs.falcon_region }}
         INPUT_VERSION: ${{ inputs.version }}
         INPUT_FALCON_IMAGE_PLATFORM: ${{ inputs.falcon_image_platform }}
+        INPUT_RETRY_MAX_ATTEMPTS: ${{ inputs.retry_max_attempts }}
+        INPUT_RETRY_DELAY_SECONDS: ${{ inputs.retry_delay_seconds }}
 
     - name: Run Falconutil patch-image
       id: falconutil-run

--- a/falconutil-pull.sh
+++ b/falconutil-pull.sh
@@ -9,6 +9,26 @@ log() {
     echo "[$(date +'%Y-%m-%dT%H:%M:%S')] $log_level: $1" >&2
 }
 
+# Retry a command up to a fixed number of attempts with a short backoff.
+# Used to ride out transient network failures (e.g. TLS handshake timeouts)
+# when contacting GitHub or the CrowdStrike registry.
+retry() {
+    local max_attempts=${INPUT_RETRY_MAX_ATTEMPTS:-3}
+    local delay=${INPUT_RETRY_DELAY_SECONDS:-5}
+    local attempt=1
+
+    while true; do
+        "$@" && return 0
+        if (( attempt >= max_attempts )); then
+            log "Command failed after ${attempt} attempt(s): $*" "ERROR"
+            return 1
+        fi
+        log "Attempt ${attempt}/${max_attempts} failed, retrying in ${delay}s: $*" "WARN"
+        sleep "$delay"
+        (( attempt++ ))
+    done
+}
+
 validate_required_inputs() {
     local invalid=false
     local -a required_inputs=(
@@ -30,14 +50,18 @@ validate_required_inputs() {
 validate_required_inputs
 
 # Download the falcon-container-sensor-pull.sh script
-curl -O https://raw.githubusercontent.com/CrowdStrike/falcon-scripts/main/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+retry curl -fsSL -O https://raw.githubusercontent.com/CrowdStrike/falcon-scripts/main/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
 
 # Check if the version is provided
 VERSION=${INPUT_VERSION:+"--version ${INPUT_VERSION}"}
 # check if the falcon image platform is provided
 PLATFORM="--platform ${INPUT_FALCON_IMAGE_PLATFORM:-x86_64}"
 
-output=$(bash falcon-container-sensor-pull.sh -u "${INPUT_FALCON_CLIENT_ID}" -r "${INPUT_FALCON_REGION}" -t falcon-container ${VERSION} ${PLATFORM})
+pull_sensor() {
+    bash falcon-container-sensor-pull.sh -u "${INPUT_FALCON_CLIENT_ID}" -r "${INPUT_FALCON_REGION}" -t falcon-container ${VERSION} ${PLATFORM}
+}
+
+output=$(retry pull_sensor)
 
 # Extract the image name from the output
 image_name=$(echo "$output" | grep "^registry.*.com/falcon-container" | tail -n 1)


### PR DESCRIPTION
Wraps the falcon-container-sensor-pull.sh download and the sensor image pull in a retry helper to ride out transient network errors such as TLS handshake timeouts. Adds retry_max_attempts and retry_delay_seconds action inputs (defaults 3 and 5), so existing workflows are unaffected.